### PR TITLE
Remove hyphen from panel_custom examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Keep the server running. Now add the following entry to your `configuration.yaml
 ```yaml
 panel_custom:
     # This is the name of the web component that will be defined by the panel
-  - name: react-panel
+  - name: reactpanel
     sidebar_title: React Demo
     sidebar_icon: mdi:react
     # This is the url that will load the panel
@@ -57,7 +57,7 @@ We then have to configure Home Assitant to use it:
 
 ```yaml
 panel_custom:
-  - name: react-panel
+  - name: reactpanel
     sidebar_title: React Prod
     sidebar_icon: mdi:react
     url_path: react-panel-prod


### PR DESCRIPTION
The current examples give the error:
```yaml
Invalid config for [panel_custom]: invalid slug react-panel (try reactpanel) for dictionary value @ data['panel_custom'][1]['name']. Got 'react-panel'. (See /config/configuration.yaml, line 104). Please check the docs at https://home-assistant.io/components/panel_custom/
```

This removes the hyphen in the examples